### PR TITLE
Remove fdlib.h and typedefs.h inclusion guards

### DIFF
--- a/capdAlg/include/capd/vectalg/fdlib.h
+++ b/capdAlg/include/capd/vectalg/fdlib.h
@@ -13,9 +13,6 @@
 // distributed under the terms of the GNU General Public License.
 // Consult  http://capd.ii.uj.edu.pl/ for details.
 
-#ifndef CAPD_VECTALG_FDLIB_H
-#define CAPD_VECTALG_FDLIB_H
-
 double power(int val,int ile);
 
 #include "capd/intervals/lib.h"
@@ -28,5 +25,3 @@ double power(int val,int ile);
 #include "capd/vectalg/Multiindex.h"
 
 #include "capd/vectalg/typedefs.h"
-
-#endif // CAPD_VECTALG_FDLIB_H

--- a/capdAlg/include/capd/vectalg/typedefs.h
+++ b/capdAlg/include/capd/vectalg/typedefs.h
@@ -13,9 +13,6 @@
 // distributed under the terms of the GNU General Public License.
 // Consult  http://capd.ii.uj.edu.pl/ for details.
 
-#ifndef CAPD_VECTALG_TYPEDEFS_H
-#define CAPD_VECTALG_TYPEDEFS_H
-
 #ifndef CAPD_DEFAULT_DIMENSION
 #error "Define macro CAPD_DEFAULT_DIMENSION before including capd/vectalg/typedefs.h"
 #endif
@@ -64,5 +61,3 @@ typedef capd::vectalg::Multiindex Multiindex;
 typedef capd::vectalg::Multipointer Multipointer;
 
 } // end of the namespace
-
-#endif // CAPD_VECTALG_TYPEDEFS_H

--- a/capdDynSys/include/capd/diffAlgebra/fdlib.h
+++ b/capdDynSys/include/capd/diffAlgebra/fdlib.h
@@ -14,9 +14,6 @@
 // distributed under the terms of the GNU General Public License.
 // Consult  http://capd.ii.uj.edu.pl/ for details.
 
-#ifndef CAPD_DIFFALGEBRA_FDLIB_H
-#define CAPD_DIFFALGEBRA_FDLIB_H
-
 #include "capd/diffAlgebra/C0TimeJet.h"
 #include "capd/diffAlgebra/C1TimeJet.h"
 #include "capd/diffAlgebra/C2TimeJet.h"
@@ -49,6 +46,4 @@ typedef capd::diffAlgebra::Jet<CAPD_USER_NAMESPACE::LDMatrix,0> LDJet;
 typedef capd::diffAlgebra::Jet<CAPD_USER_NAMESPACE::IMatrix,0> IJet;
 
 } // end of namespace CAPD_USER_NAMESPACE
-
-#endif // CAPD_DIFFALGEBRA_FDLIB_H
 

--- a/capdDynSys/include/capd/dynset/fdlib.h
+++ b/capdDynSys/include/capd/dynset/fdlib.h
@@ -13,9 +13,6 @@
 // distributed under the terms of the GNU General Public License.
 // Consult  http://capd.ii.uj.edu.pl/ for details.
 
-#ifndef CAPD_DYNSET_FDLIB_H
-#define CAPD_DYNSET_FDLIB_H
-
 #include "capd/dynset/reorganization/InvBByCFactorReorganization.h"
 #include "capd/dynset/reorganization/FactorReorganization.h"
 #include "capd/dynset/reorganization/QRReorganization.h"
@@ -40,7 +37,3 @@
 #include "capd/dynset/CnRect2Set.hpp"
 
 #include "capd/dynset/typedefs.h"
-
-#endif // CAPD_DYNSET_FDLIB_H
-
-

--- a/capdDynSys/include/capd/dynset/typedefs.h
+++ b/capdDynSys/include/capd/dynset/typedefs.h
@@ -13,9 +13,6 @@
 // distributed under the terms of the GNU General Public License.
 // Consult  http://capd.ii.uj.edu.pl/ for details.
 
-#ifndef CAPD_DYNSET_TYPEDEFS_H
-#define CAPD_DYNSET_TYPEDEFS_H
-
 #include "QRPolicy.h" // @todo Why is that needed?
 
 namespace CAPD_USER_NAMESPACE{
@@ -72,5 +69,3 @@ typedef capd::dynset::CnDoubletonSet<CAPD_USER_NAMESPACE::IMatrix,C2Rect2Policie
 
 /// @}
 } // end of namespace
-
-#endif // CAPD_DYNSET_TYPEDEFS_H

--- a/capdDynSys/include/capd/dynsys/fdlib.h
+++ b/capdDynSys/include/capd/dynsys/fdlib.h
@@ -13,9 +13,6 @@
 // distributed under the terms of the GNU General Public License.
 // Consult  http://capd.ii.uj.edu.pl/ for details.
 
-#ifndef CAPD_DYNSYS_FDLIB_H
-#define CAPD_DYNSYS_FDLIB_H
-
 #include "capd/basicalg/factrial.h"
 #include "capd/dynsys/SolverException.h"
 #include "capd/dynsys/OdeSolver.hpp"
@@ -23,5 +20,3 @@
 #include "capd/dynsys/CnOdeSolver.hpp"
 
 #include "capd/dynsys/typedefs.h"
-
-#endif // CAPD_DYNSYS_FDLIB_H

--- a/capdDynSys/include/capd/dynsys/typedefs.h
+++ b/capdDynSys/include/capd/dynsys/typedefs.h
@@ -13,9 +13,6 @@
 // distributed under the terms of the GNU General Public License.
 // Consult  http://capd.ii.uj.edu.pl/ for details.
 
-#ifndef CAPD_DYNSYS_TYPEDEFS_H
-#define CAPD_DYNSYS_TYPEDEFS_H
-
 namespace CAPD_USER_NAMESPACE{
 
 typedef capd::dynsys::DynSys<CAPD_USER_NAMESPACE::IMatrix> IDynSys;
@@ -52,5 +49,3 @@ typedef capd::dynsys::BasicC2OdeSolver<CAPD_USER_NAMESPACE::LDMap> LDC2Taylor;
 typedef capd::dynsys::BasicCnOdeSolver<CAPD_USER_NAMESPACE::LDMap> LDCnTaylor;
 
 } // end of namespace capd
-
-#endif // CAPD_DYNSYS_TYPEDEFS_H

--- a/capdDynSys/include/capd/map/fdlib.h
+++ b/capdDynSys/include/capd/map/fdlib.h
@@ -13,9 +13,6 @@
 // distributed under the terms of the GNU General Public License.
 // Consult  http://capd.ii.uj.edu.pl/ for details.
 
-#ifndef CAPD_MAP_FDLIB_H
-#define CAPD_MAP_FDLIB_H
-
 #include "capd/map/Function.hpp"
 #include "capd/map/Map.hpp"
 
@@ -31,5 +28,3 @@ typedef capd::map::Function<CAPD_USER_NAMESPACE::LDVector> LDFunction;
 typedef capd::map::Map<CAPD_USER_NAMESPACE::LDMatrix> LDMap;
 
 }
-
-#endif // CAPD_MAP_FDLIB_H

--- a/capdDynSys/include/capd/poincare/fdlib.h
+++ b/capdDynSys/include/capd/poincare/fdlib.h
@@ -13,9 +13,6 @@
 // distributed under the terms of the GNU General Public License.
 // Consult  http://capd.ii.uj.edu.pl/ for details.
 
-#ifndef CAPD_POINCARE_FDLIB_H
-#define CAPD_POINCARE_FDLIB_H
-
 #include "capd/poincare/PoincareMap.hpp"
 #include "capd/poincare/TimeMap.hpp"
 #include "capd/poincare/AffineSection.h"
@@ -23,5 +20,3 @@
 #include "capd/poincare/NonlinearSection.h"
 #include "capd/poincare/AbstractSection.hpp"
 #include "capd/poincare/typedefs.h"
-
-#endif // CAPD_POINCARE_FDLIB_H

--- a/capdDynSys/include/capd/poincare/typedefs.h
+++ b/capdDynSys/include/capd/poincare/typedefs.h
@@ -13,9 +13,6 @@
 // distributed under the terms of the GNU General Public License.
 // Consult  http://capd.ii.uj.edu.pl/ for details.
 
-#ifndef CAPD_POINCARE_TYPEDEFS_H
-#define CAPD_POINCARE_TYPEDEFS_H
-
 namespace CAPD_USER_NAMESPACE{
 
 // classes for nonrigorous computations
@@ -62,5 +59,3 @@ typedef capd::poincare::TimeMap<CAPD_USER_NAMESPACE::IC2OdeSolver> IC2TimeMap;
 typedef capd::poincare::TimeMap<CAPD_USER_NAMESPACE::ICnOdeSolver> ICnTimeMap;
 
 } // end of namespace capd
-
-#endif // CAPD_POINCARE_TYPEDEFS_H


### PR DESCRIPTION
Inclusion guards were incorrectly added for `fdlib.h` and `typedefs.h` headers in #16 . These changes are reverted in this PR.