### PR TITLE
Add missing Math.h header

### DIFF
--- a/capdAlg/include/CMakeLists.txt
+++ b/capdAlg/include/CMakeLists.txt
@@ -5,6 +5,7 @@ install_headers(
     capd/basicalg/factrial.h
     capd/basicalg/ieeePrimitive.h
     capd/basicalg/logtwo.h
+    capd/basicalg/Math.h
     capd/basicalg/minmax.h
     capd/basicalg/power.h
     capd/basicalg/powerThree.h


### PR DESCRIPTION
Minor fix to add missing Math.h header to list of headers to fix the installation.